### PR TITLE
Added new Constraint on Bind method

### DIFF
--- a/src/Formo/Configuration.cs
+++ b/src/Formo/Configuration.cs
@@ -87,7 +87,7 @@ namespace Formo
             return ConfigurationManager.AppSettings[name];
         }
 
-        public T Bind<T>()
+        public T Bind<T>() where T : new()
         {
             var instance = Activator.CreateInstance<T>();
             var binder = new SettingsBinder();


### PR DESCRIPTION
Added the Contraint because Activator.CreateInstance will need a public default parameterless constructor.
