### PR TITLE
Throwing nice exception if value could not be parsed

### DIFF
--- a/src/Formo.Tests/FormoTests.cs
+++ b/src/Formo.Tests/FormoTests.cs
@@ -95,6 +95,13 @@ namespace Formo.Tests
 
             Assert.That(actual, Is.EqualTo(true));
         }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentException), ExpectedMessage="Could not obtain value \"NonParsableInt\" from configuration file")]
+        public void Should_throw_nice_exception_when_could_not_parse()
+        {
+            configuration.NonParsableInt<Int32>();
+        }
     }
 
     public class When_key_is_in_configuration_file : ConfigurationTestBase

--- a/src/Formo.Tests/app.config
+++ b/src/Formo.Tests/app.config
@@ -13,6 +13,7 @@
     <add key="AcceptableFailurePercentage" value="1.05"/>
     <add key="IsLoggingEnabled" value="true"/>
     <add key="weird:key" value="some value"/>
+    <add key="NonParsableInt" value="NOT_AN_INT" />
     
     <!-- settings used in BindTests.cs -->
     <add key="Herp" value="herp" />
@@ -30,7 +31,7 @@
     <add key="AcceptableFailurePercentage" value="1.05"/>
     <add key="IsLoggingEnabled" value="true"/>
     <add key="weird:key" value="some value"/>
-
+    
     <!-- settings used in BindTests.cs -->
     <add key="Herp" value="herp" />
     <add key="WebsiteSettingsDerp" value="derp" />

--- a/src/Formo/Configuration.cs
+++ b/src/Formo/Configuration.cs
@@ -94,7 +94,14 @@ namespace Formo
 
             var value = GetValue(binder.Name).OrFallbackTo(args);
 
-            result = generic != null ? ConvertValue(generic, value) : value;
+            try
+            {
+                result = generic != null ? ConvertValue(generic, value) : value;
+            }
+            catch (Exception ex)
+            {
+                throw new ArgumentException(string.Format("Could not obtain value \"{0}\" from configuration file", binder.Name), ex);
+            }
 
             return true;
         }


### PR DESCRIPTION
If value could not be parsed (or generally, obtained) nice exception is thrown, so that troubleshooting of such cases should be easier. (The exception points, that it is a problem with a value in configuration file that could not be parsed)