### PR TITLE
Enables Exceptions on null configuration values

### DIFF
--- a/src/Formo.Tests/FormoTests.cs
+++ b/src/Formo.Tests/FormoTests.cs
@@ -138,19 +138,20 @@ namespace Formo.Tests
 
     public class When_key_isnt_in_configuration_file : ConfigurationTestBase
     {
-        public When_key_isnt_in_configuration_file()
+        public When_key_isnt_in_configuration_file(bool throwIfNull)
+            :base(throwIfNull)
         {
             
         }
 
-        protected When_key_isnt_in_configuration_file(string sectionName)
-            :base(sectionName)
+        protected When_key_isnt_in_configuration_file(string sectionName, bool throwIfNull)
+            :base(sectionName, throwIfNull)
         {
         }
 
 
         [Test]
-        public void Method_with_many_params_should_return_first_non_null()
+        protected void Method_with_many_params_should_return_first_non_null()
         {
             string first = null;
             var second = default(string);
@@ -159,7 +160,7 @@ namespace Formo.Tests
         }
 
         [Test]
-        public void Method_looking_for_bool_should_behave_as_ConfigurationManager()
+        protected void Method_looking_for_bool_should_behave_as_ConfigurationManager()
         {
             var key = "IsSettingMissing";
             var expected = ConfigurationManager.AppSettings[key];
@@ -169,7 +170,7 @@ namespace Formo.Tests
         }
 
         [Test]
-        public void Method_with_param_should_return_first()
+        protected void Method_with_param_should_return_first()
         {
             Assert.AreEqual("blargh", configuration.Missing("blargh"));
         }
@@ -178,11 +179,12 @@ namespace Formo.Tests
     public class When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_false : When_key_isnt_in_configuration_file
     {
         public When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_false()
+            :base(false)
         {
             
         }
         public When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_false(string sectionName)
-            : base(sectionName)
+            : base(sectionName, false)
         {
         }
 
@@ -203,11 +205,12 @@ namespace Formo.Tests
     public class When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_true : When_key_isnt_in_configuration_file
     {
         public When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_true()
+            :base(true)
         {
 
         }
         public When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_true(string sectionName)
-            : base(sectionName)
+            : base(sectionName, true)
         {
         }
 
@@ -306,16 +309,16 @@ namespace Formo.Tests
 
     public class ConfigurationTestBase
     {
-        public ConfigurationTestBase(string sectionName)
+        public ConfigurationTestBase(string sectionName, bool throwIfNull = false)
         {
-            configuration = new Configuration(sectionName);
+            configuration = new Configuration(sectionName) { ThrowIfNull = throwIfNull };
         }
 
-        public ConfigurationTestBase()
+        public ConfigurationTestBase(bool throwIfNull = false)
         {
-            configuration = new Configuration();
+            configuration = new Configuration() {ThrowIfNull = throwIfNull};
         }
 
-        protected dynamic configuration;
+        protected readonly dynamic configuration;
     }
 }

--- a/src/Formo.Tests/FormoTests.cs
+++ b/src/Formo.Tests/FormoTests.cs
@@ -97,10 +97,13 @@ namespace Formo.Tests
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentException), ExpectedMessage="Could not obtain value \"NonParsableInt\" from configuration file")]
         public void Should_throw_nice_exception_when_could_not_parse()
         {
-            configuration.NonParsableInt<Int32>();
+            var ex = Assert.Throws<InvalidCastException>(() => configuration.NonParsableInt<Int32>());
+
+            Assert.That(ex.Message, Is.EqualTo(
+                "Unable to cast setting value 'NOT_AN_INT' to 'System.Int32'" + Environment.NewLine +
+                "> Could not obtain value 'NonParsableInt' from configuration file" + Environment.NewLine));
         }
     }
 

--- a/src/Formo.Tests/FormoTests.cs
+++ b/src/Formo.Tests/FormoTests.cs
@@ -142,28 +142,12 @@ namespace Formo.Tests
         {
             
         }
-        public When_key_isnt_in_configuration_file(string sectionName)
-            : base(sectionName)
+
+        protected When_key_isnt_in_configuration_file(string sectionName)
+            :base(sectionName)
         {
         }
 
-        [Test]
-        public void Property_should_be_null()
-        {
-            Assert.Null(configuration.Missing);
-        }
-
-        [Test]
-        public void Method_should_be_null()
-        {
-            Assert.Null(configuration.Misssing());
-        }
-
-        [Test]
-        public void Method_with_param_should_return_first()
-        {
-            Assert.AreEqual("blargh", configuration.Missing("blargh"));
-        }
 
         [Test]
         public void Method_with_many_params_should_return_first_non_null()
@@ -183,6 +167,64 @@ namespace Formo.Tests
 
             Assert.AreSame(expected, actual);
         }
+
+        [Test]
+        public void Method_with_param_should_return_first()
+        {
+            Assert.AreEqual("blargh", configuration.Missing("blargh"));
+        }
+    }
+
+    public class When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_false : When_key_isnt_in_configuration_file
+    {
+        public When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_false()
+        {
+            
+        }
+        public When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_false(string sectionName)
+            : base(sectionName)
+        {
+        }
+
+        [Test]
+        public void Property_should_be_null()
+        {
+            Assert.Null(configuration.Missing);
+        }
+
+        [Test]
+        public void Method_should_be_null()
+        {
+            Assert.Null(configuration.Misssing());
+        }
+
+    }
+
+    public class When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_true : When_key_isnt_in_configuration_file
+    {
+        public When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_true()
+        {
+
+        }
+        public When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_true(string sectionName)
+            : base(sectionName)
+        {
+        }
+
+        [Test]
+        [ExpectedException(typeof(NullReferenceException))]
+        public void Property_should_throw_NullReferenceException()
+        {
+            var shouldThrow = configuration.Missing;
+        }
+
+        [Test]
+        [ExpectedException(typeof(NullReferenceException))]
+        public void Method_should_be_null()
+        {
+            var shouldThrow = configuration.Misssing();
+        }
+        
     }
 
     [TestFixture]

--- a/src/Formo.Tests/FormoTests.cs
+++ b/src/Formo.Tests/FormoTests.cs
@@ -95,6 +95,13 @@ namespace Formo.Tests
 
             Assert.That(actual, Is.EqualTo(true));
         }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentException), ExpectedMessage="Could not obtain value \"NonParsableInt\" from configuration file")]
+        public void Should_throw_nice_exception_when_could_not_parse()
+        {
+            configuration.NonParsableInt<Int32>();
+        }
     }
 
     public class When_key_is_in_configuration_file : ConfigurationTestBase

--- a/src/Formo.Tests/FormoTests.cs
+++ b/src/Formo.Tests/FormoTests.cs
@@ -148,8 +148,8 @@ namespace Formo.Tests
 
     public class When_key_isnt_in_configuration_file : ConfigurationTestBase
     {
-        public When_key_isnt_in_configuration_file(bool throwIfNull)
-            :base(throwIfNull)
+        public When_key_isnt_in_configuration_file()
+            :base(false)
         {
             
         }
@@ -159,9 +159,8 @@ namespace Formo.Tests
         {
         }
 
-
         [Test]
-        protected void Method_with_many_params_should_return_first_non_null()
+        public void Method_with_many_params_should_return_first_non_null()
         {
             string first = null;
             var second = default(string);
@@ -170,7 +169,7 @@ namespace Formo.Tests
         }
 
         [Test]
-        protected void Method_looking_for_bool_should_behave_as_ConfigurationManager()
+        public void Method_looking_for_bool_should_behave_as_ConfigurationManager()
         {
             var key = "IsSettingMissing";
             var expected = ConfigurationManager.AppSettings[key];
@@ -180,13 +179,13 @@ namespace Formo.Tests
         }
 
         [Test]
-        protected void Method_with_param_should_return_first()
+        public void Method_with_param_should_return_first()
         {
             Assert.AreEqual("blargh", configuration.Missing("blargh"));
         }
     }
 
-    public class When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_false : When_key_isnt_in_configuration_file
+    public class When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_false : ConfigurationTestBase
     {
         public When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_false()
             :base(false)
@@ -212,7 +211,7 @@ namespace Formo.Tests
 
     }
 
-    public class When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_true : When_key_isnt_in_configuration_file
+    public class When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_true : ConfigurationTestBase
     {
         public When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_true()
             :base(true)
@@ -225,17 +224,23 @@ namespace Formo.Tests
         }
 
         [Test]
-        [ExpectedException(typeof(NullReferenceException), ExpectedMessage = "Could not get key \"Missing\" from the configuration file.")]
         public void Property_should_throw_NullReferenceException()
         {
-            var shouldThrow = configuration.Missing;
+            var missing = default(dynamic);
+            var ex = Assert.Throws<InvalidOperationException>(() => missing = configuration.Missing);
+
+            Assert.Null(missing);
+            Assert.That(ex.Message, Is.EqualTo("Unable to locate a value for 'Missing' from configuration file"));
         }
 
         [Test]
-        [ExpectedException(typeof(NullReferenceException), ExpectedMessage = "Could not get key \"Missing\" from the configuration file.")]
         public void Method_should_be_null()
         {
-            var shouldThrow = configuration.Missing();
+            var missing = default(dynamic);
+            var ex = Assert.Throws<InvalidOperationException>(() => missing = configuration.Missing());
+
+            Assert.Null(missing);
+            Assert.That(ex.Message, Is.EqualTo("Unable to locate a value for 'Missing' from configuration file"));
         }
         
     }
@@ -326,7 +331,7 @@ namespace Formo.Tests
 
         public ConfigurationTestBase(bool throwIfNull = false)
         {
-            configuration = new Configuration() {ThrowIfNull = throwIfNull};
+            configuration = new Configuration { ThrowIfNull = throwIfNull };
         }
 
         protected readonly dynamic configuration;

--- a/src/Formo.Tests/FormoTests.cs
+++ b/src/Formo.Tests/FormoTests.cs
@@ -215,17 +215,17 @@ namespace Formo.Tests
         }
 
         [Test]
-        [ExpectedException(typeof(NullReferenceException))]
+        [ExpectedException(typeof(NullReferenceException), ExpectedMessage = "Could not get key \"Missing\" from the configuration file.")]
         public void Property_should_throw_NullReferenceException()
         {
             var shouldThrow = configuration.Missing;
         }
 
         [Test]
-        [ExpectedException(typeof(NullReferenceException))]
+        [ExpectedException(typeof(NullReferenceException), ExpectedMessage = "Could not get key \"Missing\" from the configuration file.")]
         public void Method_should_be_null()
         {
-            var shouldThrow = configuration.Misssing();
+            var shouldThrow = configuration.Missing();
         }
         
     }

--- a/src/Formo.Tests/FormoTests_AppSettings.cs
+++ b/src/Formo.Tests/FormoTests_AppSettings.cs
@@ -37,9 +37,19 @@ namespace Formo.Tests
     }
 
     [TestFixture]
-    public class When_key_isnt_in_configuration_file_AppSettings : When_key_isnt_in_configuration_file
+    public class When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_false_AppSettings : When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_false
     {
-        public When_key_isnt_in_configuration_file_AppSettings()
+        public When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_false_AppSettings()
+            : base("appSettings")
+        {
+
+        }
+    }
+
+    [TestFixture]
+    public class When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_true_AppSettings : When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_true
+    {
+        public When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_true_AppSettings()
             : base("appSettings")
         {
 

--- a/src/Formo.Tests/FormoTests_CustomSection.cs
+++ b/src/Formo.Tests/FormoTests_CustomSection.cs
@@ -37,9 +37,19 @@ namespace Formo.Tests
     }
 
     [TestFixture]
-    public class When_key_isnt_in_configuration_file_CustomSection : When_key_isnt_in_configuration_file
+    public class When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_false_CustomSection : When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_false
     {
-        public When_key_isnt_in_configuration_file_CustomSection()
+        public When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_false_CustomSection()
+            : base("customSection")
+        {
+
+        }
+    }
+
+    [TestFixture]
+    public class When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_true_CustomSection : When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_true
+    {
+        public When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_true_CustomSection()
             : base("customSection")
         {
 

--- a/src/Formo.Tests/FormoTests_Default.cs
+++ b/src/Formo.Tests/FormoTests_Default.cs
@@ -25,12 +25,6 @@ namespace Formo.Tests
     }
 
     [TestFixture]
-    public class When_key_isnt_in_configuration_file_Default : When_key_isnt_in_configuration_file
-    {
-
-    }
-
-    [TestFixture]
     public class When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_false_Default : When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_false
     {
     }

--- a/src/Formo.Tests/FormoTests_Default.cs
+++ b/src/Formo.Tests/FormoTests_Default.cs
@@ -29,4 +29,14 @@ namespace Formo.Tests
     {
 
     }
+
+    [TestFixture]
+    public class When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_false_Default : When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_false
+    {
+    }
+
+    [TestFixture]
+    public class When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_true_Default : When_key_isnt_in_configuration_file_and_ThrowIfNull_set_to_true
+    {
+    }
 }

--- a/src/Formo.Tests/app.config
+++ b/src/Formo.Tests/app.config
@@ -13,6 +13,7 @@
     <add key="AcceptableFailurePercentage" value="1.05"/>
     <add key="IsLoggingEnabled" value="true"/>
     <add key="weird:key" value="some value"/>
+    <add key="NonParsableInt" value="NOT_AN_INT" />
     
     <!-- settings used in BindTests.cs -->
     <add key="Herp" value="herp" />
@@ -30,7 +31,7 @@
     <add key="AcceptableFailurePercentage" value="1.05"/>
     <add key="IsLoggingEnabled" value="true"/>
     <add key="weird:key" value="some value"/>
-
+    
     <!-- settings used in BindTests.cs -->
     <add key="Herp" value="herp" />
     <add key="WebsiteSettingsDerp" value="derp" />

--- a/src/Formo.Tests/app.config
+++ b/src/Formo.Tests/app.config
@@ -31,7 +31,8 @@
     <add key="AcceptableFailurePercentage" value="1.05"/>
     <add key="IsLoggingEnabled" value="true"/>
     <add key="weird:key" value="some value"/>
-    
+    <add key="NonParsableInt" value="NOT_AN_INT" />
+
     <!-- settings used in BindTests.cs -->
     <add key="Herp" value="herp" />
     <add key="WebsiteSettingsDerp" value="derp" />

--- a/src/Formo/Configuration.cs
+++ b/src/Formo/Configuration.cs
@@ -102,7 +102,8 @@ namespace Formo
             }
             catch (Exception ex)
             {
-                throw new ArgumentException(string.Format("Could not obtain value \"{0}\" from configuration file", binder.Name), ex);
+                var message = "Could not obtain value '{0}' from configuration file".FormatWith(binder.Name);
+                throw ThrowHelper.FailedCast(generic, value, message, ex);
             }
 
             return true;

--- a/src/Formo/Configuration.cs
+++ b/src/Formo/Configuration.cs
@@ -14,6 +14,8 @@ namespace Formo
     public class Configuration : DynamicObject
     {
         private const string AppSettingsSectionName = "appSettings";
+
+        public bool ThrowIfNull { get; set; }
         private readonly NameValueCollection _section;
         private readonly CultureInfo _cultureInfo;
         private readonly List<TypeConverter> conversions = new List<TypeConverter>();

--- a/src/Formo/Configuration.cs
+++ b/src/Formo/Configuration.cs
@@ -61,7 +61,19 @@ namespace Formo
 
             var typeConverter = TypeDescriptor.GetConverter(destinationType);
             if (typeConverter.CanConvertFrom(value.GetType()))
-                return typeConverter.ConvertFrom(null, _cultureInfo, value);
+            {
+                try
+                {
+                    return typeConverter.ConvertFrom(null, _cultureInfo, value);
+                }
+                catch (Exception ex)
+                {
+                    if (ex.InnerException is FormatException)
+                        throw ex.InnerException;
+
+                    throw;
+                }
+            }
 
             var converter = conversions.FirstOrDefault(x => x.CanConvertFrom(value.GetType()));
             if (converter != null)
@@ -100,7 +112,7 @@ namespace Formo
             {
                 result = generic != null ? ConvertValue(generic, value) : value;
             }
-            catch (Exception ex)
+            catch (FormatException ex)
             {
                 var message = "Could not obtain value '{0}' from configuration file".FormatWith(binder.Name);
                 throw ThrowHelper.FailedCast(generic, value, message, ex);

--- a/src/Formo/Configuration.cs
+++ b/src/Formo/Configuration.cs
@@ -96,7 +96,14 @@ namespace Formo
 
             var value = GetValue(binder.Name).OrFallbackTo(args);
 
-            result = generic != null ? ConvertValue(generic, value) : value;
+            try
+            {
+                result = generic != null ? ConvertValue(generic, value) : value;
+            }
+            catch (Exception ex)
+            {
+                throw new ArgumentException(string.Format("Could not obtain value \"{0}\" from configuration file", binder.Name), ex);
+            }
 
             return true;
         }

--- a/src/Formo/Configuration.cs
+++ b/src/Formo/Configuration.cs
@@ -135,7 +135,7 @@ namespace Formo
 
             if(ThrowIfNull && value == null)
             {
-                throw new NullReferenceException(string.Format("Could not get key \"{0}\" from the configuration file.", name));
+                throw new InvalidOperationException("Unable to locate a value for '{0}' from configuration file".FormatWith(name));
             }
 
             return value;

--- a/src/Formo/Configuration.cs
+++ b/src/Formo/Configuration.cs
@@ -111,7 +111,14 @@ namespace Formo
 
         protected virtual string GetValue(string name)
         {
-            return _section[name];
+            var value = _section[name];
+
+            if(ThrowIfNull && value == null)
+            {
+                throw new NullReferenceException(string.Format("Could not get key \"{0}\" from the configuration file.", name));
+            }
+
+            return value;
         }
 
         public T Bind<T>() where T : new()

--- a/src/Formo/Properties/AssemblyInfo.cs
+++ b/src/Formo/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.3.*")]
-[assembly: AssemblyFileVersion("1.4.3.*")]
+[assembly: AssemblyVersion("1.4.4.*")]
+[assembly: AssemblyFileVersion("1.4.4.*")]

--- a/src/Formo/ThrowHelper.cs
+++ b/src/Formo/ThrowHelper.cs
@@ -4,7 +4,7 @@ namespace Formo
 {
     internal class ThrowHelper
     {
-        internal static Exception FailedCast(Type attemptedType, object value, string optionalMessage = null)
+        internal static Exception FailedCast(Type attemptedType, object value, string optionalMessage = null, Exception ex = null)
         {
             var message = "Unable to cast setting value '{0}' to '{1}'"
                 .FormatWith(value ?? "(null)", attemptedType);
@@ -12,7 +12,7 @@ namespace Formo
             if (optionalMessage != null)
                 message += (Environment.NewLine + "> " + optionalMessage + Environment.NewLine);
 
-            return new InvalidCastException(message);
+            return new InvalidCastException(message, ex);
         }
     }
 }


### PR DESCRIPTION
If `Configuration.ThrowIfNull` is set to `true`, Configuration will throw an exception if the requested key is null.