### PR TITLE
Add support for Microsoft.WindowsAzure.Configuration 3.0.0.0

### DIFF
--- a/src/Formo.Cloud/CloudConfiguration.cs
+++ b/src/Formo.Cloud/CloudConfiguration.cs
@@ -1,12 +1,22 @@
-﻿using Microsoft.WindowsAzure;
+﻿using System.Reflection;
 
 namespace Formo.Cloud
 {
     public class CloudConfiguration : Configuration
     {
+        private static readonly MethodInfo GetSettingMethod;
+
+        static CloudConfiguration()
+        {
+            var assembly = Assembly.Load("Microsoft.WindowsAzure.Configuration");
+            var type = assembly.GetType("Microsoft.Azure.CloudConfigurationManager")
+                ?? assembly.GetType("Microsoft.WindowsAzure.CloudConfigurationManager");
+            GetSettingMethod = type.GetMethod("GetSetting", BindingFlags.Static | BindingFlags.Public);
+        }
+
         protected override string GetValue(string name)
         {
-            return CloudConfigurationManager.GetSetting(name);
+            return (string) GetSettingMethod.Invoke(null, new object[] {name});
         }
     }
-}
+}}


### PR DESCRIPTION
CloudConfigurationManager was moved from the Microsoft.WindowsAzure namespace to Microsoft.Azure. 

As a result, the Formo.Cloud NuGet package is no longer compatible with the latest version of Microsoft.WindowsAzure.Configuration, even with the correct bindingRedirects.

This change uses reflection to call CloudConfigurationManager in the appropriate namespace without breaking existing clients.
